### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Web Developer Tool
 
 ![preview](http://alloyteam.github.io/AlloyLever/asset/alloylever2.png)
 
-###AJAX
+### AJAX
 
 ![preview](http://alloyteam.github.io/AlloyLever/asset/alloylever3.png)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,7 +6,7 @@ Web Developer Tool
 
 ![preview](http://alloyteam.github.io/AlloyLever/asset/alloylever2.png)
 
-###AJAX
+### AJAX
 
 ![preview](http://alloyteam.github.io/AlloyLever/asset/alloylever3.png)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
