### PR TITLE
Update CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ There are two purposes for URL parameter arousal, the first is to display the vC
 npm install alloylever
 ```
 
-or get js by the cdn address:
+or include this in your html:
 
-[https://unpkg.com/alloylever@1.0.2/alloy-lever.js](https://unpkg.com/alloylever@1.0.2/alloy-lever.js)
+```html
+<script src="https://cdn.jsdelivr.net/npm/alloylever@1/alloy-lever.min.js"></script>
+```
 
 ## Usage
 


### PR DESCRIPTION
I replaced the unpkg link with a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/alloylever) in your readme. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network, better reliability and is the only OSS CDN with a valid ICP license and hundreds of servers in China.